### PR TITLE
Basic CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Check yarn cache
+        uses: actions/cache@v2
+        id: cache-yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Check node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+
+      - name: Install packages
+        run: yarn
+
+      - name: Build contracts
+        run: yarn compile
+
+      - name: Generate typechain
+        run: yarn typechain
+
+      - name: Test contracts
+        run: yarn test


### PR DESCRIPTION
# Why?

It's good to have a CI job so you don't push crap 🤣

# Potential thoughts/issues

I noticed when I run `yarn compile` typechain isn't automatically called with the compilation of the contracts. I **haven't looked into it** at all so I don't know if it was an isolated issue or if it happens to you too and/or why. 

But I do know that (for example) in [example-implementations here](https://github.com/ToucanProtocol/example-implementations) we have it set up such that when you run `yarn compile` it also generates types.